### PR TITLE
Fix for renamed packages

### DIFF
--- a/commands.lisp
+++ b/commands.lisp
@@ -25,7 +25,7 @@
           nil)
     
     (lem:switch-to-buffer buffer)
-    (lem:erase-buffer)
+    (lem:erase-buffer buffer)
     
     (flet ((newline ()
              (lem:insert-character
@@ -65,7 +65,7 @@
           
           (flet ((has-spec-p (attribute)
                    (lem-theme/spec::attribute-spec theme attribute)))
-            (let* ((all-attributes (sort (copy-list lem::*attributes*)
+            (let* ((all-attributes (sort (copy-list lem-core::*attributes*)
                                          #'string>
                                          :key #'full-symbol-name))
                    (with-spec (remove-if-not #'has-spec-p all-attributes))

--- a/spec.lisp
+++ b/spec.lisp
@@ -92,7 +92,7 @@
               (list (list :background
                           (make-color theme
                                       (background theme)))))
-            (loop for attribute in lem::*attributes*
+            (loop for attribute in lem-core::*attributes*
                   for spec = (attribute-spec theme attribute)
                   when spec
                   collect (make-attribute theme
@@ -104,8 +104,8 @@
   (:documentation "Updates theme specification in Lem's internals and reloads theme if it is enabled.")
   (:method ((theme theme))
     (setf (gethash (theme-name theme)
-                   lem::*color-themes*)
-          (lem::make-color-theme
+                   lem-core::*color-themes*)
+          (lem-core::make-color-theme
            :specs (spec theme)
            :parent nil))
     (when (eql (class-of (current-theme))


### PR DESCRIPTION
Pretty straightforward. Seems like they have just furnished around a bit in the lem core. More or less. Buffer was probably &optional in erase-buffer, but does not seem to be optional now. 

I have just compiled files and fixed errors as they were found by sbcl.